### PR TITLE
Bringing example species in new job page to config file

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -17,7 +17,7 @@ class JobsController < ApplicationController
       @job[:abacas_match_size] = 500
       @job[:abacas_match_sim] = 85
       @job[:augustus_score_threshold] = 0.8
-      @job[:taxon_id] = 5653
+      @job[:taxon_id] = CONFIG['taxon']['id']
       @job[:db_id ] = "Companion"
       @job[:ratt_transfer_type] = 'Species'
       @job.build_sequence_file

--- a/app/views/jobs/new.html.erb
+++ b/app/views/jobs/new.html.erb
@@ -25,19 +25,19 @@
     </div>
     <div style="padding-top: 20px;">
       <p>Please also give a short <b>species prefix</b> that will be used to name entities (such as genes, pseudochromosomes, etc.) generated during the annotation run. It should not contain spaces or special characters.</p>
-      <p> Example: <i>LDON</i></p>
+      <p> Example: <i><%= CONFIG['example_species']['prefix'] %></i></p>
     </div>
     <div class="input-group">
       <span class="input-group-addon" id="sizing-addon2">Species prefix</span>
-      <%= f.text_field :prefix, class: 'form-control', :placeholder => "LFOO", :aria => {:describedby => "sizing-addon2"}, required: true %>
+      <%= f.text_field :prefix, class: 'form-control', :placeholder => CONFIG['example_species']['prefix'], :aria => {:describedby => "sizing-addon2"}, required: true %>
     </div>
     <div style="padding-top: 20px;">
       <p>Finally, please provide a <b>species name</b> that describes the target species you are annotating.</p>
-      <p> Example: <i>Leishmania donovani</i></p>
+      <p> Example: <i><%= CONFIG['example_species']['name'] %></i></p>
     </div>
     <div class="input-group">
       <span class="input-group-addon" id="sizing-addon2">Species name</span>
-      <%= f.text_field :organism, class: 'form-control', :placeholder => "Leishmania donovani", :aria => {:describedby => "sizing-addon2"}, required: true %>
+      <%= f.text_field :organism, class: 'form-control', :placeholder => CONFIG['example_species']['name'], :aria => {:describedby => "sizing-addon2"}, required: true %>
     </div>
   </div>
 </div>
@@ -57,12 +57,15 @@
        <%= f.fields_for :sequence_file do |s_f| %>
          <%= s_f.file_field :file, required: true %>
        <% end %>
-       <p><a href="/examples/PfIT_05.fasta">Here</a> is an example sequence
-       input file for a <i>Plasmodium falciparum</i> IT chromosome 5 sequence
-       that can be used with the <i>Plasmodium falciparum</i> 3D7 example
-       reference set (choose below in step 4) for a quick example run.
-       To use it, please download it to your local machine and upload it using
-       the button above.</p>
+       
+       <% if (CONFIG['organism_group'] == "parasite") then %>                       
+        <p><a href="/examples/PfIT_05.fasta">Here</a> is an example sequence
+        input file for a <i>Plasmodium falciparum</i> IT chromosome 5 sequence
+        that can be used with the <i>Plasmodium falciparum</i> 3D7 example
+        reference set (choose below in step 4) for a quick example run.
+        To use it, please download it to your local machine and upload it using
+        the button above.</p>
+      <% end %>
   </div>
 </div>
 
@@ -186,7 +189,7 @@
        <%= f.number_field :augustus_score_threshold, class: 'form-control', :aria => {:describedby => "sizing-addon2"}, required: true, :step => 'any' %>
      </div>
      <div style="padding-top: 20px;"><p>Please set the following values which are required for valid GAF output.</p>
-       <p> Example: <i>5691 (for T. brucei)</i>, see <a href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi" target="_blank">NCBI Taxonomy Browser</a>. The default is 5653 (Kinetoplastida).</p></div>
+       <p> Example: <i><%= CONFIG['taxon']['example'] %></i>, see <a href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi" target="_blank">NCBI Taxonomy Browser</a>. The default is <%= CONFIG['taxon']['default'] %>.</p></div>
        <div class="input-group">
          <span class="input-group-addon" id="sizing-addon2">Taxon ID</span>
          <%= f.number_field :taxon_id, class: 'form-control', :aria => {:describedby => "sizing-addon2"}, required: true %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,7 +1,7 @@
 <div class="jumbotron">
   <%= image_tag('companion_logo.png', alt: 'Companion',
                 class: 'img-responsive center-block') %>
-  <p class="lead">Easy and reliable parasite genome annotation at the University of Glasgow.</p>
+  <p class="lead">Easy and reliable <%= CONFIG['organism_group'] %> genome annotation at the University of Glasgow.</p>
   <div class="row">
     <%= form_tag(:job_find, method: "get", class: "form-inline") do %>
       <div class="form-group">

--- a/config/companion.example
+++ b/config/companion.example
@@ -37,6 +37,14 @@ base: &default
   tmpdir: "/tmp"
   example_job_id: "b2e79c6b5f8495fe52ca297d"
   max_file_size_mb: 64
+  organism_group: "parasite"
+  example_species:
+    prefix: "LDON"
+    name: "Leishmania donovani"
+  taxon:
+    example: "5691 (for T. brucei)"
+    default: "5653 (Kinetoplastida)"
+    id: 5653
 
 development:
   <<: *default


### PR DESCRIPTION
Tested in devcompanion. This allows server-specific examples to be kept in the config file, so there is no risk of them being accidentally overwritten again in future.

Additionally, I've used the anchor/alias functionality in yml (e.g. base: &default ... <<: *default) to allow parameters common to all environments to be defined only once  (i.e. rather than repeating the same config for development, production, testing)