### PR TITLE
Fix cluster genes

### DIFF
--- a/app/workers/hard_worker.rb
+++ b/app/workers/hard_worker.rb
@@ -236,8 +236,11 @@ class HardWorker
             tr = m[2].scan(/[^|]+\|([^ )]+)/)
             tr.each do |memb|
               # HACK! needs to be done correctly for all possible transcript namings!
-              memb_id = memb[0].gsub(/(:.+$|\.\d+$|\.mRNA$|\_R[A-Z]$)/,"")
-              g = Gene.where(["gene_id LIKE ? AND (job_id = #{job[:id]} OR job_id IS NULL) AND genus = '#{r[:genus]}'", "#{memb_id}%"]).take
+              memb_id = memb[0].gsub(/(:.+$|\.\d+$|\.mRNA$|\_R[A-Z]$|\_t\d+$)/,"")
+              g = Gene.where([
+                "gene_id LIKE ? AND (job_id = #{job[:id]} AND species = '#{job[:prefix]}')" \
+                "OR (job_id IS NULL AND species = '#{r[:abbr]}')", "#{memb_id}%"
+              ]).take
               if g then
                 unless g.in?(c.genes)
                   c.genes << g

--- a/db/migrate/20221028090248_add_gene_timestamps.rb
+++ b/db/migrate/20221028090248_add_gene_timestamps.rb
@@ -1,0 +1,5 @@
+class AddGeneTimestamps < ActiveRecord::Migration[5.0]  
+  def change
+    add_timestamps :genes, null: false, default: -> { 'NOW()' }    
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20221012103732) do
+ActiveRecord::Schema.define(version: 20221028090248) do
 
   create_table "circos_images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3" do |t|
     t.string   "file_uid"
@@ -49,18 +49,20 @@ ActiveRecord::Schema.define(version: 20221012103732) do
   end
 
   create_table "genes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3" do |t|
-    t.string  "gene_id",                 null: false
-    t.integer "loc_start",               null: false
-    t.integer "loc_end",                 null: false
-    t.integer "job_id"
-    t.text    "product",   limit: 65535, null: false
-    t.string  "strand",                  null: false
-    t.string  "seqid"
-    t.string  "gtype"
-    t.string  "species"
-    t.integer "tree_id"
-    t.string  "section"
-    t.string  "genus"
+    t.string   "gene_id",                                                       null: false
+    t.integer  "loc_start",                                                     null: false
+    t.integer  "loc_end",                                                       null: false
+    t.integer  "job_id"
+    t.text     "product",    limit: 65535,                                      null: false
+    t.string   "strand",                                                        null: false
+    t.string   "seqid"
+    t.string   "gtype"
+    t.string   "species"
+    t.integer  "tree_id"
+    t.string   "section"
+    t.string   "genus"
+    t.datetime "created_at",               default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at",               default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["gene_id"], name: "index_genes_on_gene_id", using: :btree
     t.index ["job_id"], name: "index_genes_on_job_id", using: :btree
   end

--- a/lib/tasks/load_references.rake
+++ b/lib/tasks/load_references.rake
@@ -42,10 +42,10 @@ task :load_references, [:args_expr] => :environment do |t, args|
           File.open("1").read.each_line do |l|
             l.chomp!
             id, type, product, seqid, start, stop, strand = l.split("\t")
-            g = Gene.find_or_create_by(:gene_id => id, :product => product, :loc_start => start,
-                        :loc_end => stop, :strand => strand, :job => nil,
-                        :seqid => seqid, :gtype => type, :species => species,
-                        :section => section, :genus => group)
+            g = Gene.find_or_initialize_by(:gene_id => id, :species => species, :job => nil)
+            g.assign_attributes({:product => product, :loc_start => start, :loc_end => stop,
+                      :strand => strand, :seqid => seqid, :gtype => type,
+                      :genus => group, :section => section})
             if g[:loc_start] and g[:loc_end] and g[:seqid] and g[:species] and g[:gtype] then
               genes << g
             else
@@ -56,7 +56,7 @@ task :load_references, [:args_expr] => :environment do |t, args|
           File.unlink("1")
         end
         STDERR.puts "read #{genes.length} genes, importing..."
-        Gene.import genes, on_duplicate_key_ignore: true
+        Gene.import genes, on_duplicate_key_update: :all
       end
     end
     STDERR.puts "done"


### PR DESCRIPTION
* unique together gene_id and species for ref gene creation, including faster import with activerecord-import used more effectively.
* Timestamps for genes for better tracking with reference updates
* capture _t1, _t2 etc gene_id suffix for clustering.
Tested rake load_references locally and a job run to check orthology on companion-build http://companion-build.mvls.gla.ac.uk/jobs/b36c6e372dee7ba2e3ef0713